### PR TITLE
Add some optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,29 @@ gcc -o btune_example btune_example.c -lblosc2 -lm -I $CONDA_PREFIX/include/ -L $
 BTUNE_TRACE=1 DYLD_LIBRARY_PATH=$CONDA_PREFIX/lib ./btune_example rand_int.b2nd out.b2nd
 ```
 
+## Optimization tips
+
+If you would like to use the same models for different arrays, you can save the loading time and reuse the first loaded
+model with the Python context manager `ReuseModels`:
+
+```
+with blosc2_btune.ReuseModels():
+    for nchunk in range(0, nchunks):
+        b = blosc2.asarray(a[nchunk * chunk_nitems:(nchunk + 1) * chunk_nitems], chunks=(chunk_nitems,), blocks=(chunk_nitems//10,), cparams=cparams)
+        tr += time() - tref
+```
+This enables reusing the models when they are the same inside the context and manages all the references and memory
+needed to be deallocated at the end of it. Depending on your needs, this may fasten your program around a 5%. You can see
+a comparison of reusing the models and reloading them each time in the `reuse_models.py` example::
+
+```
+INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
+Creating arrays reusing loaded models
+Creating arrays reloading models each time
+Reusing time: 0.277s (2.886 GB/s)
+Reloading time: 0.282s (2.839 GB/s)
+```
+
 ## Platform support
 
 Right now, we support Btune on Intel/ARM64 Linux and Intel/ARM64 Mac and Intel on Windows, and we are providing binary wheels for these.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ with blosc2_btune.ReuseModels():
         tr += time() - tref
 ```
 This enables reusing the models when they are the same inside the context and manages all the references and memory
-needed to be deallocated at the end of it. Depending on your needs, this may fasten your program around a 5%. You can see
+needed to be deallocated at the end of it. Depending on your needs, this may accelerate your program around a 5%. You can see
 a comparison of reusing the models and reloading them each time in the `reuse_models.py` example::
 
 ```

--- a/blosc2_btune/__init__.py
+++ b/blosc2_btune/__init__.py
@@ -95,11 +95,12 @@ def set_params_defaults(**kwargs):
 
 class ReuseModels:
     def __enter__(self):
-        lib.set_reuse_models(True)
+        lib.btune_set_reuse_models(True)
 
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        lib.btune_g_models_free()
+        lib.btune_free_all_models()
+        lib.btune_set_reuse_models(False)
 
 
 if __name__ == "__main__":

--- a/blosc2_btune/__init__.py
+++ b/blosc2_btune/__init__.py
@@ -91,5 +91,18 @@ def set_params_defaults(**kwargs):
     lib.set_params_defaults(*args)
 
 
+class ReuseModels:
+    def __enter__(self):
+        libpath = get_libpath()
+        lib = ctypes.cdll.LoadLibrary(libpath)
+        lib.set_reuse_models(True)
+
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        libpath = get_libpath()
+        lib = ctypes.cdll.LoadLibrary(libpath)
+        lib.btune_g_models_free()
+
+
 if __name__ == "__main__":
     print_libpath()

--- a/blosc2_btune/__init__.py
+++ b/blosc2_btune/__init__.py
@@ -70,6 +70,10 @@ params_defaults = {
 }
 
 
+libpath = get_libpath()
+lib = ctypes.cdll.LoadLibrary(libpath)
+
+
 def set_params_defaults(**kwargs):
     # Check arguments
     not_supported = [k for k in kwargs.keys() if k not in params_defaults]
@@ -86,21 +90,15 @@ def set_params_defaults(**kwargs):
     args[1] = args[1].value
     args[-1] = args[-1].value
 
-    libpath = get_libpath()
-    lib = ctypes.cdll.LoadLibrary(libpath)
     lib.set_params_defaults(*args)
 
 
 class ReuseModels:
     def __enter__(self):
-        libpath = get_libpath()
-        lib = ctypes.cdll.LoadLibrary(libpath)
         lib.set_reuse_models(True)
 
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        libpath = get_libpath()
-        lib = ctypes.cdll.LoadLibrary(libpath)
         lib.btune_g_models_free()
 
 

--- a/examples/reuse_models.py
+++ b/examples/reuse_models.py
@@ -1,0 +1,46 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# This source code is licensed under a BSD-style license (found in the
+# LICENSE file in the root directory of this source tree)
+#######################################################################
+import blosc2
+from time import time
+import blosc2_btune
+import numpy as np
+
+# Create the data
+rng = np.random.default_rng()
+a = rng.integers(low=0, high=10000, size=int(1e5), dtype=np.int64)
+nchunks = 10
+chunk_nitems = a.size // nchunks
+
+# Set some parameters
+cparams = {
+        "tuner": blosc2.Tuner.BTUNE,
+        }
+kwargs = {
+        "perf_mode": blosc2_btune.PerformanceMode.DECOMP,
+        "models_dir": "./models/",
+        }
+blosc2_btune.set_params_defaults(**kwargs)
+
+print("Creating arrays reloading models each time")
+tl = 0
+for nchunk in range(0, nchunks):
+    tref = time()
+    b = blosc2.asarray(a[nchunk * chunk_nitems:(nchunk + 1) * chunk_nitems], cparams=cparams)
+    tl += time() - tref
+
+print("Creating arrays reusing loaded models")
+tr = 0
+with blosc2_btune.ReuseModels():
+    for nchunk in range(0, nchunks):
+        tref = time()
+        b = blosc2.asarray(a[nchunk * chunk_nitems:(nchunk + 1) * chunk_nitems], cparams=cparams)
+        tr += time() - tref
+
+size = a.size * 8 / 10**6
+print(f"Reloading time: {tl:.3f}s ({size / tl:.3f} MB/s)")
+print(f"Reusing time: {tr:.3f}s ({size / tr:.3f} MB/s)")

--- a/prebuild.sh
+++ b/prebuild.sh
@@ -31,6 +31,7 @@ git checkout $latestTag
 # Compile static version of C-Blosc2
 mkdir build
 cd build
-cmake ..
+# For some reason, without  -DDEACTIVATE_AVX512=ON btune_config.py throws an Illegal instruction (core dumped) error
+cmake .. -DDEACTIVATE_AVX512=ON
 cmake --build . --config Release --target blosc2_static -j
 cd ../..

--- a/src/btune-private.h
+++ b/src/btune-private.h
@@ -120,6 +120,8 @@ typedef struct {
   // Number of times to run inference
   bool inference_ended;
   // Whether all desired ninferences were already performed.
+  int models_index;
+  // The models index in g_models.
 } btune_struct;
 /// @endcond
 

--- a/src/btune-private.h
+++ b/src/btune-private.h
@@ -125,5 +125,13 @@ typedef struct {
 } btune_struct;
 /// @endcond
 
+// Needed for reusing the models
+typedef struct {
+    void *comp_interpreter;
+    void *comp_meta;
+    void *decomp_interpreter;
+    void *decomp_meta;
+    char *models_dir;
+} model_t;
 
 #endif  /* BTUNE_PRIVATE_H */

--- a/src/btune-private.h
+++ b/src/btune-private.h
@@ -116,8 +116,6 @@ typedef struct {
   // TF Lite model, used for inference
   void * metadata;
   // Metadata information used for model inference
-  float zeros_speed;
-  // Entropy speed for a zeros chunk.
   int inference_count;
   // Number of times to run inference
   bool inference_ended;

--- a/src/btune.c
+++ b/src/btune.c
@@ -20,9 +20,6 @@
 #include "btune-private.h"
 
 
-bool BTUNE_REUSE_MODELS = false;
-
-
 // Disable different states
 #define BTUNE_ENABLE_SHUFFLESIZE  false
 #define BTUNE_ENABLE_MEMCPY       false
@@ -1127,10 +1124,10 @@ int set_params_defaults(
   return 0;
 }
 
-void free_all_models(void) {
-  btune_g_models_free();
+void btune_free_all_models(void) {
+  g_models_free();
 }
 
-void set_reuse_models(bool new_value) {
-  BTUNE_REUSE_MODELS = new_value;
+void btune_set_reuse_models(bool new_value) {
+  set_reuse_models(new_value);
 }

--- a/src/btune.c
+++ b/src/btune.c
@@ -482,9 +482,10 @@ int btune_init(void *tuner_params, blosc2_context * cctx, blosc2_context * dctx)
 
 // Free btune_struct
 int btune_free(blosc2_context *context) {
-  btune_model_free(context);
-
   btune_struct *btune_params = (btune_struct *) context->tuner_params;
+  if (btune_params->models_index < 0) {
+    btune_model_free(context);
+  }
   free(btune_params->best);
   free(btune_params->aux_cparams);
   free(btune_params->current_scores);
@@ -1121,4 +1122,14 @@ int set_params_defaults(
   BTUNE_CONFIG_DEFAULTS.behaviour.repeat_mode = repeat_mode;
 
   return 0;
+}
+
+void free_all_models(void) {
+  btune_g_models_free();
+}
+
+void set_reuse_models(bool new_value) {
+  printf("ab reuse models %d\n", BTUNE_REUSE_MODELS);
+  BTUNE_REUSE_MODELS = new_value;
+  printf("dp reuse models %d\n", BTUNE_REUSE_MODELS);
 }

--- a/src/btune.c
+++ b/src/btune.c
@@ -484,12 +484,14 @@ int btune_init(void *tuner_params, blosc2_context * cctx, blosc2_context * dctx)
 
 // Free btune_struct
 int btune_free(blosc2_context *context) {
-  btune_model_free(context);
+  //btune_model_free(context);
   btune_struct *btune_params = (btune_struct *) context->tuner_params;
   free(btune_params->best);
   free(btune_params->aux_cparams);
   free(btune_params->current_scores);
   free(btune_params->current_cratios);
+  btune_params->interpreter = NULL;
+  btune_params->metadata = NULL;
   free(btune_params);
   context->tuner_params = NULL;
 

--- a/src/btune.c
+++ b/src/btune.c
@@ -482,8 +482,20 @@ int btune_init(void *tuner_params, blosc2_context * cctx, blosc2_context * dctx)
 
 // Free btune_struct
 int btune_free(blosc2_context *context) {
-  //btune_model_free(context);
   btune_struct *btune_params = (btune_struct *) context->tuner_params;
+  if (btune_params->config.perf_mode == BTUNE_PERF_DECOMP) {
+    g_moldels[btune_params->models_index].nusers_decomp--;
+    if (g_moldels[btune_params->models_index].nusers_decomp == 0) {
+      btune_model_free(context);
+    }
+  } else {
+    g_moldels[btune_params->models_index].nusers_comp--;
+    if (g_moldels[btune_params->models_index].nusers_comp == 0) {
+      btune_model_free(context);
+    }
+  }
+
+
   free(btune_params->best);
   free(btune_params->aux_cparams);
   free(btune_params->current_scores);

--- a/src/btune.c
+++ b/src/btune.c
@@ -365,8 +365,6 @@ int btune_init(void *tuner_params, blosc2_context * cctx, blosc2_context * dctx)
     btune->config.tradeoff = BTUNE_CONFIG_DEFAULTS.tradeoff;
   }
 
-  btune->zeros_speed = -1; // This is initialized the first time inference is performed
-
   if (cctx->schunk != NULL) {
     // If the user does not fill the config, the next fields will be empty
     // No need to do the same for dctx because btune is only used during compression

--- a/src/btune.c
+++ b/src/btune.c
@@ -20,6 +20,9 @@
 #include "btune-private.h"
 
 
+bool BTUNE_REUSE_MODELS = false;
+
+
 // Disable different states
 #define BTUNE_ENABLE_SHUFFLESIZE  false
 #define BTUNE_ENABLE_MEMCPY       false
@@ -1129,7 +1132,5 @@ void free_all_models(void) {
 }
 
 void set_reuse_models(bool new_value) {
-  printf("ab reuse models %d\n", BTUNE_REUSE_MODELS);
   BTUNE_REUSE_MODELS = new_value;
-  printf("dp reuse models %d\n", BTUNE_REUSE_MODELS);
 }

--- a/src/btune.c
+++ b/src/btune.c
@@ -482,20 +482,9 @@ int btune_init(void *tuner_params, blosc2_context * cctx, blosc2_context * dctx)
 
 // Free btune_struct
 int btune_free(blosc2_context *context) {
+  btune_model_free(context);
+
   btune_struct *btune_params = (btune_struct *) context->tuner_params;
-  if (btune_params->config.perf_mode == BTUNE_PERF_DECOMP) {
-    g_moldels[btune_params->models_index].nusers_decomp--;
-    if (g_moldels[btune_params->models_index].nusers_decomp == 0) {
-      btune_model_free(context);
-    }
-  } else {
-    g_moldels[btune_params->models_index].nusers_comp--;
-    if (g_moldels[btune_params->models_index].nusers_comp == 0) {
-      btune_model_free(context);
-    }
-  }
-
-
   free(btune_params->best);
   free(btune_params->aux_cparams);
   free(btune_params->current_scores);

--- a/src/btune.h
+++ b/src/btune.h
@@ -208,13 +208,4 @@ typedef enum {
 } readapt_type;
 
 
-typedef struct {
-    void *comp_interpreter;
-    void *comp_meta;
-    void *decomp_interpreter;
-    void *decomp_meta;
-    char *models_dir;
-} model_t;
-
-
 #endif  /* BTUNE_H */

--- a/src/btune.h
+++ b/src/btune.h
@@ -208,4 +208,15 @@ typedef enum {
 } readapt_type;
 
 
+typedef struct {
+    void *comp_interpreter;
+    void *comp_meta;
+    int nusers_comp;
+    void *decomp_interpreter;
+    void *decomp_meta;
+    int nusers_decomp;
+    char *models_dir;
+} model_t;
+
+
 #endif  /* BTUNE_H */

--- a/src/btune.h
+++ b/src/btune.h
@@ -211,12 +211,12 @@ typedef enum {
 typedef struct {
     void *comp_interpreter;
     void *comp_meta;
-    int nusers_comp;
     void *decomp_interpreter;
     void *decomp_meta;
-    int nusers_decomp;
     char *models_dir;
 } model_t;
 
+
+static bool BTUNE_REUSE_MODELS = false;
 
 #endif  /* BTUNE_H */

--- a/src/btune.h
+++ b/src/btune.h
@@ -208,4 +208,7 @@ typedef enum {
 } readapt_type;
 
 
+extern bool BTUNE_REUSE_MODELS;
+
+
 #endif  /* BTUNE_H */

--- a/src/btune.h
+++ b/src/btune.h
@@ -217,6 +217,4 @@ typedef struct {
 } model_t;
 
 
-static bool BTUNE_REUSE_MODELS = false;
-
 #endif  /* BTUNE_H */

--- a/src/btune.h
+++ b/src/btune.h
@@ -208,7 +208,4 @@ typedef enum {
 } readapt_type;
 
 
-extern bool BTUNE_REUSE_MODELS;
-
-
 #endif  /* BTUNE_H */

--- a/src/btune_info_public.h
+++ b/src/btune_info_public.h
@@ -33,6 +33,10 @@ BLOSC2_BTUNE_EXPORT int set_params_defaults(
     uint32_t repeat_mode
 );
 
+BLOSC2_BTUNE_EXPORT void free_all_models(void);
+
+BLOSC2_BTUNE_EXPORT void set_reuse_models(bool new_value);
+
 /**
  * @brief Btune initializer.
  *

--- a/src/btune_info_public.h
+++ b/src/btune_info_public.h
@@ -33,9 +33,9 @@ BLOSC2_BTUNE_EXPORT int set_params_defaults(
     uint32_t repeat_mode
 );
 
-BLOSC2_BTUNE_EXPORT void free_all_models(void);
+BLOSC2_BTUNE_EXPORT void btune_free_all_models(void);
 
-BLOSC2_BTUNE_EXPORT void set_reuse_models(bool new_value);
+BLOSC2_BTUNE_EXPORT void btune_set_reuse_models(bool new_value);
 
 /**
  * @brief Btune initializer.

--- a/src/btune_model.cpp
+++ b/src/btune_model.cpp
@@ -384,6 +384,8 @@ void btune_model_init(blosc2_context * ctx) {
   }
   strcpy(config->models_dir, dirname);
 
+  // The models_index will be overwritten in case the models are being reused
+  btune_params->models_index = -1;
   if (BTUNE_REUSE_MODELS) {
     // Use already loaded models if available
     bool models_found = false;
@@ -422,7 +424,6 @@ void btune_model_init(blosc2_context * ctx) {
       btune_params->metadata = load_metadata(config, dirname);
       if (nmodels_dir >= 255) {
         BTUNE_TRACE("Reached maximum number of loaded models dir");
-        btune_params->models_index = -1;
       } else {
         btune_params->models_index = nmodels_dir;
         g_models[nmodels_dir].models_dir = (char *)malloc(strlen(config->models_dir) + 1);

--- a/src/btune_model.cpp
+++ b/src/btune_model.cpp
@@ -45,7 +45,7 @@ typedef struct {
 model_t g_models[256];
 int nmodels_dir = 0;
 
-extern bool BTUNE_REUSE_MODELS;
+bool BTUNE_REUSE_MODELS = false;
 
 float zeros_speed = -1.;
 
@@ -530,7 +530,7 @@ void btune_model_free(blosc2_context * ctx) {
 }
 
 // Free all the models and its metadata used until now
-void btune_g_models_free(void) {
+void g_models_free(void) {
   for (int i = 0; i < nmodels_dir; ++i) {
     delete g_models[i].decomp_interpreter;
     g_models[i].decomp_interpreter = NULL;
@@ -553,6 +553,10 @@ void btune_g_models_free(void) {
     free(g_models[i].models_dir);
   }
   nmodels_dir = 0;
+}
+
+void set_reuse_models(bool new_value) {
+  BTUNE_REUSE_MODELS = new_value;
 }
 
 

--- a/src/btune_model.cpp
+++ b/src/btune_model.cpp
@@ -42,11 +42,8 @@ typedef struct {
 } metadata_t;
 
 
-
-
-
-extern model_t g_models[256];
-extern int nmodels_dir = 0;
+model_t g_models[256];
+int nmodels_dir = 0;
 
 float zeros_speed = -1.;
 
@@ -511,7 +508,23 @@ int most_predicted(btune_struct *btune_params, int *compcode,
 
 void btune_model_free(blosc2_context * ctx) {
   btune_struct *btune_params = (btune_struct *) ctx->tuner_params;
+  if (btune_params->config.perf_mode == BTUNE_PERF_DECOMP) {
+    g_models[btune_params->models_index].nusers_decomp--;
+    if (g_models[btune_params->models_index].nusers_decomp == 0) {
+      g_models[btune_params->models_index].decomp_interpreter = NULL;
+      g_models[btune_params->models_index].decomp_meta = NULL;
+      goto proceed;
+    }
+  } else {
+    g_models[btune_params->models_index].nusers_comp--;
+    if (g_models[btune_params->models_index].nusers_comp == 0) {
+      goto proceed;
+    }
+  }
+  return;
 
+  proceed:
+  printf("proceed0\n");
   delete btune_params->interpreter;
   btune_params->interpreter = NULL;
 
@@ -521,4 +534,6 @@ void btune_model_free(blosc2_context * ctx) {
     free(metadata);
     btune_params->metadata = NULL;
   }
+  printf("proceed1\n");
+
 }

--- a/src/btune_model.cpp
+++ b/src/btune_model.cpp
@@ -45,6 +45,8 @@ typedef struct {
 model_t g_models[256];
 int nmodels_dir = 0;
 
+extern bool BTUNE_REUSE_MODELS;
+
 float zeros_speed = -1.;
 
 
@@ -350,7 +352,6 @@ static void * load_model(btune_config * config, const char * dirname) {
 }
 
 void btune_model_init(blosc2_context * ctx) {
-printf("dins init models, nmodels_dir = %d\n", nmodels_dir);
   // Trace time
   bool trace = getenv("BTUNE_TRACE");
   blosc_timestamp_t t0, t1;

--- a/src/btune_model.cpp
+++ b/src/btune_model.cpp
@@ -46,6 +46,7 @@ void *comp_interpreter;
 void *comp_meta;
 void *decomp_interpreter;
 void *decomp_meta;
+float zeros_speed = -1.;
 
 
 static int fsize(FILE *file) {
@@ -136,12 +137,12 @@ static int get_best_codec_for_chunk(
   // dparams
   blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
   blosc2_context *dctx = blosc2_create_dctx(dparams);
-  if (btune->zeros_speed < 0.) {
+  if (zeros_speed < 0.) {
     // Compress zeros chunk to get a machine relative speed measure
-    btune->zeros_speed = get_zeros_speed(size);
-    if (btune->zeros_speed < 0.) {
-        fprintf(stderr, "Error %d computing zeros speed\n", (int)btune->zeros_speed);
-        return btune->zeros_speed;
+    zeros_speed = get_zeros_speed(size);
+    if (zeros_speed < 0.) {
+        fprintf(stderr, "Error %d computing zeros speed\n", (int)zeros_speed);
+        return zeros_speed;
     }
   }
 
@@ -192,7 +193,7 @@ static int get_best_codec_for_chunk(
       cratio += instr_data->cratio;
       float ctime = 1.f / instr_data->cspeed;
       float ftime = 1.f / instr_data->filter_speed;
-      rel_speed += 1.f / (ctime + ftime) / btune->zeros_speed;
+      rel_speed += 1.f / (ctime + ftime) / zeros_speed;
     }
     instr_data++;
     special_val = instr_data->flags[0];
@@ -384,11 +385,13 @@ void btune_model_init(blosc2_context * ctx) {
 
   if (config->perf_mode == BTUNE_PERF_DECOMP) {
     if (decomp_interpreter == NULL) {
+      printf("carrega\n");
       btune_params->interpreter = load_model(config, dirname);
       btune_params->metadata = load_metadata(config, dirname);
       decomp_interpreter = btune_params->interpreter;
       decomp_meta = btune_params->metadata;
     } else {
+      printf("usa\n");
       btune_params->interpreter = decomp_interpreter;
       btune_params->metadata = decomp_meta;
     }

--- a/src/btune_model.h
+++ b/src/btune_model.h
@@ -28,7 +28,9 @@ void btune_model_free(blosc2_context * ctx);
 int most_predicted(btune_struct *btune_params, int *compcode,
                    uint8_t *filter, int *clevel, int32_t *splitmode);
 
-void btune_g_models_free(void);
+void g_models_free(void);
+
+void set_reuse_models(bool new_value);
 
 #ifdef __cplusplus
 }

--- a/src/btune_model.h
+++ b/src/btune_model.h
@@ -28,6 +28,8 @@ void btune_model_free(blosc2_context * ctx);
 int most_predicted(btune_struct *btune_params, int *compcode,
                    uint8_t *filter, int *clevel, int32_t *splitmode);
 
+void btune_g_models_free(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Only compute once the zeros_speed needed to perform the inference each time.
- Create a python context manager to be able to reuse already loaded models from different arrays. This saves the loading time as well as the memory needed to store them.